### PR TITLE
Combinator-based Operator Precedence

### DIFF
--- a/src/expression/binary_math.rs
+++ b/src/expression/binary_math.rs
@@ -109,10 +109,6 @@ impl Expression for BinaryMath {
     }
 }
 
-pub(super) fn parse_binary_math_expression(input: &str) -> ExpressionParseResult {
-    addition_parser(multiplication_parser(super::parse_primary))(input)
-}
-
 pub(super) fn addition_parser<F>(next_parser: F) -> impl Fn(&str) -> ExpressionParseResult
 where
     F: Fn(&str) -> ExpressionParseResult,
@@ -211,21 +207,23 @@ mod tests {
     #[test]
     fn binary_expressions_can_parse() {
         let (context, record) = empty_context_and_record();
-        let result = parse_binary_math_expression("1 + 2 - 3 + 4 - 5.5");
+        let parser = addition_parser(multiplication_parser(parse_literal));
+
+        let result = parser("1 + 2 - 3 + 4 - 5.5");
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap().1.evaluate(&context, &record),
             Value::Numeric(NumericValue::Float(-1.5)),
         );
 
-        let result = parse_binary_math_expression("1 * 2 + 3 * 4");
+        let result = parser("1 * 2 + 3 * 4");
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap().1.evaluate(&context, &record),
             Value::Numeric(NumericValue::Integer(14)),
         );
 
-        let result = parse_binary_math_expression("6 / 5 * 4 / 3");
+        let result = parser("6 / 5 * 4 / 3");
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap().1.evaluate(&context, &record),
@@ -233,14 +231,14 @@ mod tests {
             Value::Numeric(NumericValue::Float(1.5999999999999999)),
         );
 
-        let result = parse_binary_math_expression("6 / 3");
+        let result = parser("6 / 3");
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap().1.evaluate(&context, &record),
             Value::Numeric(NumericValue::Integer(2)),
         );
 
-        let result = parse_binary_math_expression("6 % 5 * 4 / 3 % 2");
+        let result = parser("6 % 5 * 4 / 3 % 2");
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap().1.evaluate(&context, &record),

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -54,10 +54,6 @@ where
     }
 }
 
-pub(super) fn parse_field_reference(input: &str) -> ExpressionParseResult {
-    field_reference_parser(super::parse_primary)(input)
-}
-
 #[cfg(test)]
 mod tests {
     use super::super::literal::*;
@@ -90,7 +86,9 @@ mod tests {
     #[test]
     fn test_parse_field_reference() {
         let (context, mut record) = empty_context_and_record();
-        let result = parse_field_reference("$1");
+        let parser = field_reference_parser(parse_literal);
+
+        let result = parser("$1");
         assert_eq!(result.is_ok(), true);
         let expression = result.unwrap().1;
         assert_eq!(expression.evaluate(&context, &record), Value::Uninitialized,);

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -99,4 +99,19 @@ mod tests {
             Value::String("hello".to_string()),
         );
     }
+
+    #[test]
+    // fn test_nested_field_references() {
+    //     let (context, mut record) = empty_context_and_record();
+    //     record.fields = vec!["2", "3", "hello"];
+
+    //     let parser = field_reference_parser(parse_literal);
+    //     let result = parser("$$$1");
+    //     assert!(result.is_ok(), true);
+    //     let expression = result.unwrap().1;
+    //     assert_eq!(
+    //         expression.evaluate(&context, &record),
+    //         Value::String("hello".to_string()),
+    //     );
+    // }
 }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_assignable(input: &str) -> IResult<&str, Box<dyn Assign>> {
 
 pub(crate) fn parse_expression(input: &str) -> ExpressionParseResult {
     alt((
-        regex_match::parse_regex_match,
+        regex_match::regex_parser(binary_math::parse_binary_math_expression),
         binary_math::parse_binary_math_expression,
     ))(input)
 }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -38,7 +38,8 @@ pub(crate) fn parse_assignable(input: &str) -> IResult<&str, Box<dyn Assign>> {
 
 pub(crate) fn parse_expression(input: &str) -> ExpressionParseResult {
     // Descending order of precedence
-    let multiplication_parser = binary_math::multiplication_parser(field_reference::parse_field_reference);
+    let field_reference_parser = field_reference::field_reference_parser(parse_primary);
+    let multiplication_parser = binary_math::multiplication_parser(|i| field_reference_parser(i));
     let addition_parser = binary_math::addition_parser(|i| multiplication_parser(i));
     let regex_parser = regex_match::regex_parser(|i| addition_parser(i));
 
@@ -47,6 +48,7 @@ pub(crate) fn parse_expression(input: &str) -> ExpressionParseResult {
         |i| regex_parser(i),
         |i| addition_parser(i),
         |i| multiplication_parser(i),
+        |i| field_reference_parser(i),
     ));
 
     parser(input)

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_assignable(input: &str) -> IResult<&str, Box<dyn Assign>> {
 
 pub(crate) fn parse_expression(input: &str) -> ExpressionParseResult {
     // Descending order of precedence
-    let multiplication_parser = binary_math::multiplication_parser(parse_primary);
+    let multiplication_parser = binary_math::multiplication_parser(field_reference::parse_field_reference);
     let addition_parser = binary_math::addition_parser(|i| multiplication_parser(i));
     let regex_parser = regex_match::regex_parser(|i| addition_parser(i));
 
@@ -57,7 +57,6 @@ fn parse_primary(input: &str) -> ExpressionParseResult {
         literal::parse_literal,
         variable::parse_variable,
         parse_parens,
-        field_reference::parse_field_reference,
     ))(input)
 }
 

--- a/src/expression/regex_match.rs
+++ b/src/expression/regex_match.rs
@@ -69,31 +69,9 @@ where
     }
 }
 
-// Regex matching does not associate
-pub(super) fn parse_regex_match(input: &str) -> ExpressionParseResult {
-    let (i, (left, operator, right)) = tuple((
-        super::binary_math::parse_binary_math_expression,
-        delimited(multispace0, alt((tag("~"), tag("!~"))), multispace0),
-        super::binary_math::parse_binary_math_expression,
-    ))(input)?;
-
-    let negated = match operator {
-        "~" => false,
-        "!~" => true,
-        _ => panic!("Unexpected regex operator length: {}", operator),
-    };
-    Result::Ok((
-        i,
-        Box::new(RegexMatch {
-            left: left,
-            right: right,
-            negated,
-        }),
-    ))
-}
-
 #[cfg(test)]
 mod tests {
+    use super::super::binary_math::parse_binary_math_expression;
     use super::*;
 
     fn empty_context_and_record() -> (Context, Record<'static>) {
@@ -110,7 +88,7 @@ mod tests {
     fn test_regex_match() {
         let (context, record) = empty_context_and_record();
 
-        let result = parse_regex_match("1 ~ 2");
+        let result = regex_parser(parse_binary_math_expression)("1 ~ 2");
         assert!(result.is_ok());
         let expression = result.unwrap().1;
         assert_eq!(
@@ -119,11 +97,11 @@ mod tests {
         );
 
         // Cannot consume the full expression
-        let result = parse_regex_match("1 ~ 2 ~ 3");
+        let result = regex_parser(parse_binary_math_expression)("1 ~ 2 ~ 3");
         assert!(result.is_ok());
         assert_eq!(result.unwrap().0, " ~ 3");
 
-        let result = parse_regex_match("1 + 2 ~ 3");
+        let result = regex_parser(parse_binary_math_expression)("1 + 2 ~ 3");
         assert!(result.is_ok());
         let (remainder, expression) = result.unwrap();
         assert_eq!(remainder, "");
@@ -132,7 +110,7 @@ mod tests {
             Value::Numeric(NumericValue::Integer(1)),
         );
 
-        let result = parse_regex_match("1 !~ 2");
+        let result = regex_parser(parse_binary_math_expression)("1 !~ 2");
         assert!(result.is_ok());
         let expression = result.unwrap().1;
         assert_eq!(

--- a/src/expression/regex_match.rs
+++ b/src/expression/regex_match.rs
@@ -71,7 +71,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::binary_math::parse_binary_math_expression;
+    use super::super::{binary_math::addition_parser, literal::parse_literal};
     use super::*;
 
     fn empty_context_and_record() -> (Context, Record<'static>) {
@@ -87,8 +87,9 @@ mod tests {
     #[test]
     fn test_regex_match() {
         let (context, record) = empty_context_and_record();
+        let parser = regex_parser(addition_parser(parse_literal));
 
-        let result = regex_parser(parse_binary_math_expression)("1 ~ 2");
+        let result = parser("1 ~ 2");
         assert!(result.is_ok());
         let expression = result.unwrap().1;
         assert_eq!(
@@ -97,11 +98,11 @@ mod tests {
         );
 
         // Cannot consume the full expression
-        let result = regex_parser(parse_binary_math_expression)("1 ~ 2 ~ 3");
+        let result = parser("1 ~ 2 ~ 3");
         assert!(result.is_ok());
         assert_eq!(result.unwrap().0, " ~ 3");
 
-        let result = regex_parser(parse_binary_math_expression)("1 + 2 ~ 3");
+        let result = parser("1 + 2 ~ 3");
         assert!(result.is_ok());
         let (remainder, expression) = result.unwrap();
         assert_eq!(remainder, "");
@@ -110,7 +111,7 @@ mod tests {
             Value::Numeric(NumericValue::Integer(1)),
         );
 
-        let result = regex_parser(parse_binary_math_expression)("1 !~ 2");
+        let result = parser("1 !~ 2");
         assert!(result.is_ok());
         let expression = result.unwrap().1;
         assert_eq!(


### PR DESCRIPTION
In the grammar, there is a precedence of operators.

The [best practice](https://craftinginterpreters.com/parsing-expressions.html) way to handle this in an LL parser (as Nom is) is to create layers of parsers that are only allowed to "go up" a level when using parentheses.

Since I don't want individual parsers to know what the next layer down is, let's pass them in as a parameter.