### PR TITLE
Behavior: Reuse specification for variable names in command-line parsing

### DIFF
--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -22,6 +22,8 @@ mod literal;
 mod regex_match;
 mod variable;
 
+pub use variable::parse_variable_name;
+
 pub(crate) trait Expression: Debug {
     fn evaluate<'a>(&self, context: &Context, record: &'a Record) -> Value;
 

--- a/src/expression/variable.rs
+++ b/src/expression/variable.rs
@@ -51,7 +51,8 @@ pub(super) fn parse_assignable_variable(input: &str) -> IResult<&str, Box<dyn As
     ))
 }
 
-fn parse_variable_name(input: &str) -> IResult<&str, &str> {
+// Public for use in parse_args
+pub fn parse_variable_name(input: &str) -> IResult<&str, &str> {
     re_find!(input, r"^[A-Za-z_][A-Za-z0-9_]*")
 }
 


### PR DESCRIPTION
Implements #35 