### PR TITLE
Add custom functions

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -428,4 +428,13 @@ mod tests {
             empty_vec,
         );
     }
+
+    #[test]
+    fn test_assign_from_function() {
+        let (functions, mut context, record) = empty_context_and_record();
+        let result = parse_simple_statement(r#"variable = hello("hi")"#);
+        assert!(result.is_ok());
+        let (remaining, statement) = result.unwrap();
+        assert_eq!(remaining, "");
+    }
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -11,6 +11,7 @@ use nom::{
 use crate::{
     basic_types::{Context, Record},
     expression::{parse_assignable, parse_expression, Assign, Expression},
+    function::Functions,
 };
 
 #[derive(Debug)]
@@ -21,12 +22,13 @@ pub(crate) struct Action {
 impl Action {
     pub(crate) fn output_for_line<'a>(
         &self,
+        functions: &Functions,
         context: &mut Context,
         record: &Record<'a>,
     ) -> Vec<String> {
         self.statements
             .iter()
-            .flat_map(|statement| statement.evaluate(context, record))
+            .flat_map(|statement| statement.evaluate(functions, context, record))
             .collect()
     }
 }
@@ -67,7 +69,12 @@ enum Statement {
 }
 
 impl Statement {
-    fn evaluate<'a>(&self, context: &mut Context, record: &'a Record) -> Vec<String> {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Vec<String> {
         match self {
             Statement::Print(expressions) => {
                 let output_line = expressions
@@ -84,9 +91,9 @@ impl Statement {
             } => {
                 let result = condition.evaluate(context, record).coercion_to_boolean();
                 if result {
-                    if_branch.output_for_line(context, record)
+                    if_branch.output_for_line(functions, context, record)
                 } else {
-                    else_branch.output_for_line(context, record)
+                    else_branch.output_for_line(functions, context, record)
                 }
             }
             Statement::Assign { assignable, value } => {
@@ -99,7 +106,7 @@ impl Statement {
                 let mut output = vec![];
                 loop {
                     if value.coercion_to_boolean() {
-                        output.append(&mut body.output_for_line(context, record));
+                        output.append(&mut body.output_for_line(functions, context, record));
                         value = condition.evaluate(context, record);
                     } else {
                         break;
@@ -110,7 +117,7 @@ impl Statement {
             Statement::DoWhile { body, condition } => {
                 let mut output = vec![];
                 loop {
-                    output.append(&mut body.output_for_line(context, record));
+                    output.append(&mut body.output_for_line(functions, context, record));
                     let value = condition.evaluate(context, record);
                     if !value.coercion_to_boolean() {
                         break;
@@ -241,10 +248,13 @@ fn parse_assign_statement(input: &str) -> IResult<&str, Statement> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::function::Functions;
     use crate::value::{NumericValue, Value};
+    use std::collections::HashMap;
 
-    fn empty_context_and_record() -> (Context, Record<'static>) {
+    fn empty_context_and_record() -> (Functions, Context, Record<'static>) {
         (
+            HashMap::new(),
             Context::empty(),
             Record {
                 full_line: "",
@@ -255,17 +265,17 @@ mod tests {
 
     #[test]
     fn print_statement_produces_value() {
-        let (mut empty_context, record) = empty_context_and_record();
+        let (functions, mut empty_context, record) = empty_context_and_record();
         let print_action = parse_action(r#"{ print("hello"); }"#).unwrap().1;
         assert_eq!(
-            print_action.output_for_line(&mut empty_context, &record),
+            print_action.output_for_line(&functions, &mut empty_context, &record),
             vec!["hello"],
         );
     }
 
     #[test]
     fn if_produces_correct_value() {
-        let (mut empty_context, record) = empty_context_and_record();
+        let (functions, mut empty_context, record) = empty_context_and_record();
 
         let if_conditional = parse_action(
             r#"{
@@ -279,7 +289,7 @@ mod tests {
         .unwrap()
         .1;
         assert_eq!(
-            if_conditional.output_for_line(&mut empty_context, &record),
+            if_conditional.output_for_line(&functions, &mut empty_context, &record),
             vec!["if-branch"],
         );
 
@@ -295,14 +305,14 @@ mod tests {
         .unwrap()
         .1;
         assert_eq!(
-            else_conditional.output_for_line(&mut empty_context, &record),
+            else_conditional.output_for_line(&functions, &mut empty_context, &record),
             vec!["else"],
         );
     }
 
     #[test]
     fn assignment_updates_context() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
 
         let assign_action = parse_action(
             r#"{
@@ -311,7 +321,7 @@ mod tests {
         )
         .unwrap()
         .1;
-        assign_action.output_for_line(&mut context, &record);
+        assign_action.output_for_line(&functions, &mut context, &record);
         assert_eq!(
             context.fetch_variable("foo"),
             Value::Numeric(NumericValue::Integer(3)),
@@ -320,14 +330,14 @@ mod tests {
 
     #[test]
     fn test_parse_statements() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let result = parse_print_statement(r#"print("hello")"#);
         assert!(result.is_ok());
         assert_eq!(
             Action {
                 statements: vec![result.unwrap().1]
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             vec!["hello"],
         );
 
@@ -342,14 +352,14 @@ mod tests {
             Action {
                 statements: result.unwrap().1
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             vec!["1", "2 extra arg", "hello",],
         );
     }
 
     #[test]
     fn test_parse_if_else_statement() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let result = parse_simple_statement(
             r#"if (1) {
             print("hello");
@@ -360,14 +370,14 @@ mod tests {
             Action {
                 statements: vec![result.unwrap().1]
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             vec!["hello"],
         );
     }
 
     #[test]
     fn test_parse_while_statement() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let result = parse_simple_statement(
             r#"while (0) {
                 print("hello");
@@ -379,14 +389,14 @@ mod tests {
             Action {
                 statements: vec![result.unwrap().1]
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             empty_vec,
         );
     }
 
     #[test]
     fn test_parse_do_while_statement() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let result = parse_simple_statement(
             r#"do {
                 print("hello");
@@ -397,13 +407,13 @@ mod tests {
             Action {
                 statements: vec![result.unwrap().1]
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             vec!["hello"],
         );
     }
     #[test]
     fn test_parse_assign_statement() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let result = parse_simple_statement(r#"variable = "hi""#);
         let empty_vec: Vec<&'static str> = vec![];
         assert!(result.is_ok());
@@ -411,7 +421,7 @@ mod tests {
             Action {
                 statements: vec![result.unwrap().1]
             }
-            .output_for_line(&mut context, &record),
+            .output_for_line(&functions, &mut context, &record),
             empty_vec,
         );
     }

--- a/src/action.rs
+++ b/src/action.rs
@@ -79,7 +79,7 @@ impl Statement {
             Statement::Print(expressions) => {
                 let output_line = expressions
                     .iter()
-                    .map(|e| e.evaluate(context, record).coerce_to_string())
+                    .map(|e| e.evaluate(functions, context, record).coerce_to_string())
                     .collect::<Vec<String>>()
                     .join(" ");
                 vec![output_line]
@@ -89,7 +89,9 @@ impl Statement {
                 if_branch,
                 else_branch,
             } => {
-                let result = condition.evaluate(context, record).coercion_to_boolean();
+                let result = condition
+                    .evaluate(functions, context, record)
+                    .coercion_to_boolean();
                 if result {
                     if_branch.output_for_line(functions, context, record)
                 } else {
@@ -97,17 +99,18 @@ impl Statement {
                 }
             }
             Statement::Assign { assignable, value } => {
-                let value = value.evaluate(context, record);
+                // TODO: Check for function / variable name collision
+                let value = value.evaluate(functions, context, record);
                 assignable.assign(context, record, value);
                 vec![]
             }
             Statement::While { condition, body } => {
-                let mut value = condition.evaluate(context, record);
+                let mut value = condition.evaluate(functions, context, record);
                 let mut output = vec![];
                 loop {
                     if value.coercion_to_boolean() {
                         output.append(&mut body.output_for_line(functions, context, record));
-                        value = condition.evaluate(context, record);
+                        value = condition.evaluate(functions, context, record);
                     } else {
                         break;
                     }
@@ -118,7 +121,7 @@ impl Statement {
                 let mut output = vec![];
                 loop {
                     output.append(&mut body.output_for_line(functions, context, record));
-                    let value = condition.evaluate(context, record);
+                    let value = condition.evaluate(functions, context, record);
                     if !value.coercion_to_boolean() {
                         break;
                     }

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -3,7 +3,7 @@ use regex;
 use std::collections::HashMap;
 use std::ops::Index;
 
-use crate::function::FunctionDefinition;
+use crate::function::{FunctionDefinition, StackFrame};
 
 pub(crate) struct Record<'a> {
     pub(crate) full_line: &'a str,
@@ -22,26 +22,6 @@ pub(crate) struct Context {
     global_variables: StackFrame,
     functions: HashMap<String, FunctionDefinition>,
     function_variables: Vec<StackFrame>,
-}
-
-struct StackFrame {
-    variables: HashMap<String, Value>,
-}
-
-impl StackFrame {
-    fn empty() -> StackFrame {
-        StackFrame {
-            variables: HashMap::new(),
-        }
-    }
-
-    fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
-        self.variables.get(variable_name).map(|val| val.clone())
-    }
-
-    fn assign_variable(&mut self, variable_name: &str, value: Value) {
-        self.variables.insert(variable_name.to_string(), value);
-    }
 }
 
 impl Context {

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -16,21 +16,36 @@ enum FieldSeparator {
 
 pub(crate) struct Context {
     field_separator: FieldSeparator,
+    global_variables: StackFrame,
+}
+
+struct StackFrame {
     variables: HashMap<String, Value>,
+}
+
+impl StackFrame {
+    fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
+        self.variables.get(variable_name).map(|val| val.clone())
+    }
+
+    fn assign_variable(&mut self, variable_name: &str, value: Value) {
+        self.variables.insert(variable_name.to_string(), value);
+    }
 }
 
 impl Context {
     pub(crate) fn empty() -> Context {
         Context {
             field_separator: FieldSeparator::Character(' '),
-            variables: HashMap::new(),
+            global_variables: StackFrame {
+                variables: HashMap::new(),
+            },
         }
     }
 
     pub(crate) fn fetch_variable(&self, variable_name: &str) -> Value {
-        self.variables
-            .get(variable_name)
-            .map(|val| val.clone())
+        self.global_variables
+            .fetch_variable(variable_name)
             .unwrap_or(UNINITIALIZED_VALUE.clone())
     }
 
@@ -43,7 +58,7 @@ impl Context {
     }
 
     pub(crate) fn assign_variable(&mut self, variable_name: &str, value: Value) {
-        self.variables.insert(variable_name.to_string(), value);
+        self.global_variables.assign_variable(variable_name, value);
     }
 
     pub(super) fn split<'a>(&self, line: &'a str) -> Vec<&'a str> {

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -1,7 +1,7 @@
 use crate::value::Value;
 use regex;
 
-use crate::function::{StackFrame};
+use crate::function::StackFrame;
 
 pub(crate) struct Record<'a> {
     pub(crate) full_line: &'a str,

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -24,6 +24,12 @@ struct StackFrame {
 }
 
 impl StackFrame {
+    fn empty() -> StackFrame {
+        StackFrame {
+            variables: HashMap::new(),
+        }
+    }
+
     fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
         self.variables.get(variable_name).map(|val| val.clone())
     }
@@ -37,9 +43,7 @@ impl Context {
     pub(crate) fn empty() -> Context {
         Context {
             field_separator: FieldSeparator::Character(' '),
-            global_variables: StackFrame {
-                variables: HashMap::new(),
-            },
+            global_variables: StackFrame::empty(),
         }
     }
 

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -1,8 +1,7 @@
 use crate::value::Value;
 use regex;
-use std::collections::HashMap;
 
-use crate::function::{FunctionDefinition, StackFrame};
+use crate::function::{StackFrame};
 
 pub(crate) struct Record<'a> {
     pub(crate) full_line: &'a str,
@@ -16,10 +15,10 @@ enum FieldSeparator {
     Regex(regex::Regex),
 }
 
+// TODO: Rename this to VariableValues or something
 pub(crate) struct Context {
     field_separator: FieldSeparator,
     global_variables: StackFrame,
-    functions: HashMap<String, FunctionDefinition>,
     function_variables: Vec<StackFrame>,
 }
 
@@ -27,7 +26,6 @@ impl Context {
     pub(crate) fn empty() -> Context {
         Context {
             field_separator: FieldSeparator::Character(' '),
-            functions: HashMap::new(),
             global_variables: StackFrame::empty(),
             function_variables: vec![],
         }

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -3,6 +3,8 @@ use regex;
 use std::collections::HashMap;
 use std::ops::Index;
 
+use crate::function::FunctionDefinition;
+
 pub(crate) struct Record<'a> {
     pub(crate) full_line: &'a str,
     pub(crate) fields: Vec<&'a str>,
@@ -18,16 +20,12 @@ enum FieldSeparator {
 pub(crate) struct Context {
     field_separator: FieldSeparator,
     global_variables: StackFrame,
-    functions: HashMap<String, FunctionSignature>,
+    functions: HashMap<String, FunctionDefinition>,
     function_variables: Vec<StackFrame>,
 }
 
 struct StackFrame {
     variables: HashMap<String, Value>,
-}
-
-struct FunctionSignature {
-    variable_names: Vec<String>,
 }
 
 impl StackFrame {
@@ -87,7 +85,8 @@ impl Context {
     pub(crate) fn push_stack(&mut self, function_name: &str, variables: Vec<Value>) {
         match self.functions.get(function_name) {
             None => panic!("calling undefined function {}", function_name),
-            Some(FunctionSignature { variable_names }) => {
+            Some(def) => {
+                let variable_names = &def.variable_names;
                 let (num, expected_num) = (variables.len(), variable_names.len());
                 if num > expected_num {
                     panic!(

--- a/src/expression/binary_comparison.rs
+++ b/src/expression/binary_comparison.rs
@@ -37,7 +37,12 @@ impl Expression for BinaryComparison {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let left_value = self.left.evaluate(functions, context, record);
         let right_value = self.right.evaluate(functions, context, record);
 

--- a/src/expression/binary_math.rs
+++ b/src/expression/binary_math.rs
@@ -36,7 +36,12 @@ impl Expression for BinaryMath {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let left_value = self
             .left
             .evaluate(functions, context, record)

--- a/src/expression/boolean.rs
+++ b/src/expression/boolean.rs
@@ -33,7 +33,12 @@ impl Expression for BinaryBoolean {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let left_value = self
             .left
             .evaluate(functions, context, record)
@@ -62,7 +67,12 @@ impl Expression for NotBoolean {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let value = self
             .expression
             .evaluate(functions, context, record)

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -24,7 +24,12 @@ impl Expression for FieldReference {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let value = self
             .expression
             .evaluate(functions, context, record)

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -10,6 +10,7 @@ use nom::{
 use super::{Expression, ExpressionParseResult};
 use crate::{
     basic_types::{Context, Record},
+    function::Functions,
     value::{NumericValue, Value},
 };
 
@@ -23,10 +24,10 @@ impl Expression for FieldReference {
         None
     }
 
-    fn evaluate<'a>(&self, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
         let value = self
             .expression
-            .evaluate(context, record)
+            .evaluate(functions, context, record)
             .coerce_to_numeric();
         let unsafe_index = match value {
             NumericValue::Integer(i) => i,
@@ -64,9 +65,12 @@ where
 mod tests {
     use super::super::literal::*;
     use super::*;
+    use crate::function::Functions;
+    use std::collections::HashMap;
 
-    fn empty_context_and_record() -> (Context, Record<'static>) {
+    fn empty_context_and_record() -> (Functions, Context, Record<'static>) {
         (
+            HashMap::new(),
             Context::empty(),
             Record {
                 full_line: "",
@@ -77,45 +81,51 @@ mod tests {
 
     #[test]
     fn field_reference_can_evaluate() {
-        let (context, mut record) = empty_context_and_record();
+        let (functions, mut context, mut record) = empty_context_and_record();
         record.fields = vec!["first", "second"];
 
         assert_eq!(
             FieldReference {
                 expression: Box::new(Literal::Numeric(NumericValue::Integer(1)))
             }
-            .evaluate(&context, &record),
+            .evaluate(&functions, &mut context, &record),
             Value::String("first".to_string()),
         );
     }
 
     #[test]
     fn test_parse_field_reference() {
-        let (context, mut record) = empty_context_and_record();
+        let (functions, mut context, mut record) = empty_context_and_record();
         let parser = field_reference_parser(parse_literal);
 
         let result = parser("$1");
         assert_eq!(result.is_ok(), true);
         let expression = result.unwrap().1;
-        assert_eq!(expression.evaluate(&context, &record), Value::Uninitialized,);
+        assert_eq!(
+            expression.evaluate(&functions, &mut context, &record),
+            Value::Uninitialized,
+        );
 
         record.fields = vec!["hello"];
         assert_eq!(
-            expression.evaluate(&context, &record),
+            expression.evaluate(&functions, &mut context, &record),
             Value::String("hello".to_string()),
         );
 
         let result = parser("$     1");
         assert_eq!(result.is_ok(), true);
         assert_eq!(
-            result.unwrap().1.evaluate(&context, &record),
+            result
+                .unwrap()
+                .1
+                .evaluate(&functions, &mut context, &record),
             Value::String("hello".to_string()),
         );
     }
 
     // #[test]
     // fn test_nested_field_references() {
-    //     let (context, mut record) = empty_context_and_record();
+    //     let (functions, mut context, mut record) = empty_context_and_record();
     //     record.fields = vec!["2", "3", "hello"];
 
     //     let parser = field_reference_parser(parse_literal);
@@ -123,7 +133,7 @@ mod tests {
     //     assert!(result.is_ok(), true);
     //     let expression = result.unwrap().1;
     //     assert_eq!(
-    //         expression.evaluate(&context, &record),
+    //         expression.evaluate(&functions, &mut context, &record),
     //         Value::String("hello".to_string()),
     //     );
     // }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -91,6 +91,9 @@ mod tests {
     #[test]
     fn test_function_parsing() {
         // Assert no panic
-        parse_function_call(r#"foo("first", a, 1 + 2)"#);
+        let result = parse_function_call(r#"foo("first", a, 1 + 2, $0)"#);
+        assert!(result.is_ok());
+        let (remaining, call) = result.unwrap();
+        assert_eq!(remaining, "");
     }
 }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -1,0 +1,66 @@
+use regex::Regex;
+use std::fmt::Debug;
+
+use nom::{
+    character::complete::{multispace0, one_of},
+    combinator::map,
+    multi::many0,
+    sequence::{pair, preceded, tuple},
+};
+
+use super::{parse_expression, variable::parse_variable_name, Expression, ExpressionParseResult};
+use crate::{
+    basic_types::{Context, Record},
+    value::Value,
+};
+
+#[derive(Debug)]
+struct FunctionCall {
+    name: String,
+    arguments: Vec<Box<dyn Expression>>,
+}
+
+impl Expression for FunctionCall {
+    fn evaluate<'a>(&self, context: &Context, record: &'a Record) -> Value {
+        // TODO: Actually return a proper return value
+        Value::String("".to_string())
+    }
+
+    fn regex<'a>(&'a self) -> Option<&'a Regex> {
+        None
+    }
+}
+
+pub(crate) fn parse_function_call(input: &str) -> ExpressionParseResult {
+    let parse_arguments = map(
+        pair(
+            parse_expression,
+            many0(preceded(
+                tuple((multispace0, one_of(","), multispace0)),
+                parse_expression,
+            )),
+        ),
+        |(argument, mut arguments)| {
+            arguments.insert(0, argument);
+            arguments
+        },
+    );
+
+    let (i, (func_name, _, _, _, arguments, _, _)) = tuple((
+        parse_variable_name,
+        multispace0,
+        one_of("("),
+        multispace0,
+        parse_arguments,
+        multispace0,
+        one_of(")"),
+    ))(input)?;
+
+    Result::Ok((
+        i,
+        Box::new(FunctionCall {
+            name: func_name.to_string(),
+            arguments: arguments,
+        }),
+    ))
+}

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -28,6 +28,19 @@ impl Expression for FunctionCall {
         context: &mut Context,
         record: &'a Record,
     ) -> Value {
+        let function = match functions.get(&self.name) {
+            Some(func) => func,
+            None => panic!("Could not find function with name {}", self.name),
+        };
+        let values: Vec<Value> = self
+            .arguments
+            .iter()
+            .map(|exp| exp.evaluate(functions, context, record))
+            .collect();
+
+        // TODO: Capture this output
+        function.invoke_with(values, functions, context, record);
+
         // TODO: Actually return a proper return value
         Value::String("".to_string())
     }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -11,6 +11,7 @@ use nom::{
 use super::{parse_expression, variable::parse_variable_name, Expression, ExpressionParseResult};
 use crate::{
     basic_types::{Context, Record},
+    function::Functions,
     value::Value,
 };
 
@@ -21,7 +22,7 @@ struct FunctionCall {
 }
 
 impl Expression for FunctionCall {
-    fn evaluate<'a>(&self, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
         // TODO: Actually return a proper return value
         Value::String("".to_string())
     }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -22,7 +22,12 @@ struct FunctionCall {
 }
 
 impl Expression for FunctionCall {
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         // TODO: Actually return a proper return value
         Value::String("".to_string())
     }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -83,3 +83,14 @@ pub(crate) fn parse_function_call(input: &str) -> ExpressionParseResult {
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_function_parsing() {
+        // Assert no panic
+        parse_function_call(r#"foo("first", a, 1 + 2)"#);
+    }
+}

--- a/src/expression/literal.rs
+++ b/src/expression/literal.rs
@@ -34,7 +34,7 @@ impl Expression for Literal {
     fn evaluate<'a>(
         &self,
         _functions: &Functions,
-        _context: &Context,
+        _context: &mut Context,
         _record: &'a Record,
     ) -> Value {
         match self {

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -71,6 +71,7 @@ fn parse_primary(input: &str) -> ExpressionParseResult {
     alt((
         literal::parse_literal,
         variable::parse_variable,
+        function::parse_function_call,
         parse_parens,
     ))(input)
 }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -18,7 +18,7 @@ mod binary_comparison;
 mod binary_math;
 mod boolean;
 mod field_reference;
-// mod function;
+mod function;
 mod literal;
 mod regex_match;
 pub(crate) mod variable;

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -18,11 +18,12 @@ mod binary_comparison;
 mod binary_math;
 mod boolean;
 mod field_reference;
+// mod function;
 mod literal;
 mod regex_match;
-mod variable;
+pub(crate) mod variable;
 
-pub use variable::parse_variable_name;
+pub(crate) use variable::parse_variable_name;
 
 pub(crate) trait Expression: Debug {
     fn evaluate<'a>(&self, context: &Context, record: &'a Record) -> Value;

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -69,9 +69,9 @@ pub(crate) fn parse_expression(input: &str) -> ExpressionParseResult {
 
 fn parse_primary(input: &str) -> ExpressionParseResult {
     alt((
+        function::parse_function_call,
         literal::parse_literal,
         variable::parse_variable,
-        function::parse_function_call,
         parse_parens,
     ))(input)
 }

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -27,7 +27,12 @@ pub(crate) mod variable;
 pub(crate) use variable::parse_variable_name;
 
 pub(crate) trait Expression: Debug {
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value;
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value;
 
     fn regex<'a>(&'a self) -> Option<&'a Regex>;
 }

--- a/src/expression/regex_match.rs
+++ b/src/expression/regex_match.rs
@@ -27,7 +27,12 @@ impl Expression for RegexMatch {
         None
     }
 
-    fn evaluate<'a>(&self, functions: &Functions, context: &Context, record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &'a Record,
+    ) -> Value {
         let left_value = self
             .left
             .evaluate(functions, context, record)

--- a/src/expression/variable.rs
+++ b/src/expression/variable.rs
@@ -5,6 +5,7 @@ use nom::{re_find, IResult};
 use super::{Assign, Expression, ExpressionParseResult};
 use crate::{
     basic_types::{Context, Record},
+    function::Functions,
     value::Value,
 };
 
@@ -18,7 +19,12 @@ impl Expression for Variable {
         None
     }
 
-    fn evaluate<'a>(&self, context: &Context, _record: &'a Record) -> Value {
+    fn evaluate<'a>(
+        &self,
+        _functions: &Functions,
+        context: &Context,
+        _record: &'a Record,
+    ) -> Value {
         context.fetch_variable(&self.variable_name)
     }
 }
@@ -59,10 +65,13 @@ pub fn parse_variable_name(input: &str) -> IResult<&str, &str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::function::Functions;
     use crate::value::NumericValue;
+    use std::collections::HashMap;
 
-    fn empty_context_and_record() -> (Context, Record<'static>) {
+    fn empty_context_and_record() -> (Functions, Context, Record<'static>) {
         (
+            HashMap::new(),
             Context::empty(),
             Record {
                 full_line: "",
@@ -73,7 +82,7 @@ mod tests {
 
     #[test]
     fn variables_can_evaluate() {
-        let (mut context, record) = empty_context_and_record();
+        let (functions, mut context, record) = empty_context_and_record();
         let value = Value::Numeric(NumericValue::Integer(1));
         context.assign_variable("foo", value.clone());
 
@@ -81,7 +90,7 @@ mod tests {
             Variable {
                 variable_name: "foo".to_string()
             }
-            .evaluate(&context, &record),
+            .evaluate(&functions, &mut context, &record),
             value,
         );
     }

--- a/src/expression/variable.rs
+++ b/src/expression/variable.rs
@@ -22,7 +22,7 @@ impl Expression for Variable {
     fn evaluate<'a>(
         &self,
         _functions: &Functions,
-        context: &Context,
+        context: &mut Context,
         _record: &'a Record,
     ) -> Value {
         context.fetch_variable(&self.variable_name)

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,11 +6,33 @@ use nom::{
     sequence::{pair, preceded, tuple},
     IResult,
 };
+use std::collections::HashMap;
 
 use crate::{
     action::{parse_action, Action},
     expression::variable::parse_variable_name,
+    value::Value,
 };
+
+pub(crate) struct StackFrame {
+    variables: HashMap<String, Value>,
+}
+
+impl StackFrame {
+    pub(crate) fn empty() -> StackFrame {
+        StackFrame {
+            variables: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
+        self.variables.get(variable_name).map(|val| val.clone())
+    }
+
+    pub(crate) fn assign_variable(&mut self, variable_name: &str, value: Value) {
+        self.variables.insert(variable_name.to_string(), value);
+    }
+}
 
 pub(crate) struct FunctionDefinition {
     pub(crate) name: String,

--- a/src/function.rs
+++ b/src/function.rs
@@ -42,10 +42,13 @@ pub(crate) struct FunctionDefinition {
     body: Action,
 }
 
+pub(crate) type Functions = HashMap<String, FunctionDefinition>;
+
 impl FunctionDefinition {
     pub(crate) fn invoke_with(
         &self,
         values: Vec<Value>,
+        functions: &Functions,
         context: &mut Context,
         record: &Record,
     ) -> Vec<String> {
@@ -70,7 +73,7 @@ impl FunctionDefinition {
         // Right now, a function can only be invoked as a Statement with printable outputs.
         // In the future, a function will need to be both a "statement" (returning outputs) AND an
         // expression (having a nestable value)
-        context.with_stack_frame(frame, |c| self.body.output_for_line(c, record))
+        context.with_stack_frame(frame, |c| self.body.output_for_line(functions, c, record))
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,73 @@
+use nom::{
+    bytes::complete::tag,
+    character::complete::{multispace0, multispace1, one_of},
+    combinator::map,
+    multi::many0,
+    sequence::{pair, preceded, tuple},
+    IResult,
+};
+
+use crate::{
+    action::{parse_action, Action},
+    expression::variable::parse_variable_name,
+};
+
+pub(crate) struct FunctionDefinition {
+    pub(crate) name: String,
+    pub(crate) variable_names: Vec<String>,
+    body: Action,
+}
+
+pub(crate) fn parse_function(input: &str) -> IResult<&str, FunctionDefinition> {
+    let parse_variable_list = map(
+        pair(
+            parse_variable_name,
+            many0(preceded(
+                tuple((multispace0, one_of(","), multispace0)),
+                parse_variable_name,
+            )),
+        ),
+        |(name, mut names)| {
+            names.insert(0, name);
+            names
+        },
+    );
+    map(
+        tuple((
+            tag("function"),
+            multispace1,
+            parse_variable_name,
+            multispace0,
+            tag("("),
+            multispace0,
+            parse_variable_list,
+            multispace0,
+            tag(")"),
+            multispace0,
+            parse_action,
+        )),
+        |(_, _, func_name, _, _, _, variables, _, _, _, body)| FunctionDefinition {
+            name: func_name.to_string(),
+            variable_names: variables.iter().map(|s| s.to_string()).collect(),
+            body: body,
+        },
+    )(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_parse_function() {
+        let result = parse_function(
+            r#"function foo(a) {
+                print("hi");
+            }"#,
+        );
+        assert!(result.is_ok());
+        let function_definition = result.unwrap().1;
+        assert_eq!(function_definition.name, "foo");
+        assert_eq!(function_definition.variable_names, vec!["a"]);
+    }
+}

--- a/src/function.rs
+++ b/src/function.rs
@@ -125,7 +125,8 @@ mod tests {
             }"#,
         );
         assert!(result.is_ok());
-        let function_definition = result.unwrap().1;
+        let (remaining, function_definition) = result.unwrap();
+        assert_eq!(remaining, "");
         assert_eq!(function_definition.name, "foo");
         assert_eq!(function_definition.variable_names, vec!["a"]);
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -25,7 +25,7 @@ impl Item {
         context: &mut Context,
         record: &Record<'a>,
     ) -> Vec<String> {
-        if self.pattern.matches(context, record) {
+        if self.pattern.matches(functions, context, record) {
             self.action.output_for_line(functions, context, record)
         } else {
             vec![]

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,9 +1,4 @@
-use nom::{
-    character::complete::multispace0,
-    combinator::map,
-    sequence::tuple,
-    IResult,
-};
+use nom::{character::complete::multispace0, combinator::map, sequence::tuple, IResult};
 
 use crate::{
     action::{parse_action, Action},

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,8 +1,7 @@
 use nom::{
     character::complete::multispace0,
     combinator::map,
-    multi::many1,
-    sequence::{delimited, tuple},
+    sequence::tuple,
     IResult,
 };
 
@@ -50,11 +49,7 @@ impl Item {
     }
 }
 
-pub(crate) fn parse_item_list(input: &str) -> IResult<&str, Vec<Item>> {
-    many1(delimited(multispace0, parse_item, multispace0))(input)
-}
-
-fn parse_item(input: &str) -> IResult<&str, Item> {
+pub(crate) fn parse_item(input: &str) -> IResult<&str, Item> {
     map(
         tuple((parse_item_pattern, multispace0, parse_action)),
         |(pattern, _, action)| Item {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate regex;
 mod action;
 mod basic_types;
 mod expression;
+mod function;
 mod item;
 mod parse_args;
 mod pattern;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,11 @@
 extern crate nom;
 extern crate regex;
 
-use std::collections::HashMap;
 use nom::{
-    character::complete::multispace0,
-    multi::many1,
-    sequence::delimited,
-    IResult,
+    branch::alt, character::complete::multispace0, combinator::map, multi::many1,
+    sequence::delimited, IResult,
 };
+use std::collections::HashMap;
 
 mod action;
 mod basic_types;
@@ -20,7 +18,7 @@ mod value;
 
 use crate::{
     basic_types::{Context, Record},
-    function::Functions,
+    function::{parse_function, FunctionDefinition, Functions},
     item::{parse_item, Item},
 };
 
@@ -29,16 +27,51 @@ pub struct Program {
     functions: Functions,
 }
 
-fn parse_item_list(input: &str) -> IResult<&str, Vec<Item>> {
-    many1(delimited(multispace0, parse_item, multispace0))(input)
+enum ParsedThing {
+    Item(Item),
+    Function(FunctionDefinition),
+}
+
+fn parse_item_list(input: &str) -> IResult<&str, (Vec<Item>, Vec<FunctionDefinition>)> {
+    let parse_thing = alt((
+        map(parse_item, |item| ParsedThing::Item(item)),
+        map(parse_function, |function| ParsedThing::Function(function)),
+    ));
+
+    map(
+        many1(delimited(multispace0, parse_thing, multispace0)),
+        |things| {
+            let mut items = vec![];
+            let mut functions = vec![];
+
+            for thing in things {
+                match thing {
+                    ParsedThing::Item(item) => {
+                        items.push(item);
+                    }
+                    ParsedThing::Function(function) => {
+                        functions.push(function);
+                    }
+                }
+            }
+
+            (items, functions)
+        },
+    )(input)
 }
 
 pub fn parse_program(program_text: &str) -> Program {
     match parse_item_list(program_text) {
-        Ok((_, items)) => Program {
-            items: items,
-            functions: HashMap::new(),
-        },
+        Ok((_, (items, functions))) => {
+            let mut function_map = HashMap::new();
+            for func in functions {
+                function_map.insert(func.name.clone(), func);
+            }
+            Program {
+                items: items,
+                functions: function_map,
+            }
+        }
         Err(e) => panic!("Could not parse! {}", e),
     }
 }
@@ -115,6 +148,21 @@ mod tests {
             print(2.0);
             print("hello");
         }"#,
+        );
+    }
+
+    #[test]
+    fn test_parse_program_with_function() {
+        // Assert no panic
+        parse_program(
+            r#"{ print(1);
+            print(2.0);
+            print("hello");
+        }
+        function foo(a) {
+          print("hello");
+        }
+        "#,
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@ extern crate nom;
 extern crate regex;
 
 use std::collections::HashMap;
+use nom::{
+    character::complete::multispace0,
+    multi::many1,
+    sequence::delimited,
+    IResult,
+};
 
 mod action;
 mod basic_types;
@@ -15,12 +21,16 @@ mod value;
 use crate::{
     basic_types::{Context, Record},
     function::Functions,
-    item::{parse_item_list, Item},
+    item::{parse_item, Item},
 };
 
 pub struct Program {
     items: Vec<Item>,
     functions: Functions,
+}
+
+fn parse_item_list(input: &str) -> IResult<&str, Vec<Item>> {
+    many1(delimited(multispace0, parse_item, multispace0))(input)
 }
 
 pub fn parse_program(program_text: &str) -> Program {

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -8,6 +8,7 @@ use nom::{
 use crate::{
     basic_types::{Context, Record},
     expression::{parse_expression, Expression},
+    function::Functions,
 };
 
 pub(crate) enum Pattern {
@@ -18,12 +19,19 @@ pub(crate) enum Pattern {
 }
 
 impl Pattern {
-    pub(crate) fn matches<'a>(&self, context: &mut Context, record: &Record<'a>) -> bool {
+    pub(crate) fn matches<'a>(
+        &self,
+        functions: &Functions,
+        context: &mut Context,
+        record: &Record<'a>,
+    ) -> bool {
         match self {
             Pattern::MatchEverything => true,
             Pattern::Expression(expression) => match expression.regex() {
                 Some(regex) => regex.is_match(record.full_line),
-                None => expression.evaluate(context, record).coercion_to_boolean(),
+                None => expression
+                    .evaluate(functions, context, record)
+                    .coercion_to_boolean(),
             },
             Pattern::Begin => false,
             Pattern::End => false,


### PR DESCRIPTION
This establishes the infrastructure for:
1. Function invocation
2. Custom Function definitions

From an architecture perspective, the trickiest bit was learning to store functions as a separate collection global collection, i.e. NOT in the already-existing `Context`. This is because functions are never modified, but are extracted in the middle of expression + statement evaluation -> need to be borrowed out of the `Context`. Thus, including them in the `Context` would incur conflicting borrows (simultaneous mutable borrow to nest while an existing immutable borrow for the function reference still exists).

The other notable change in architecture was passing down a mutable `Context` into expressions. This is necessary since a function invocation will need to execute statements.

There are some TODOs left after this PR:
- Consolidating the passing around of `Functions` + `Context` + `Record` https://github.com/wenley/rust-awk/issues/59
- Propagating the output lines that functions can have https://github.com/wenley/rust-awk/issues/60
- Implementing return statements + values from Functions https://github.com/wenley/rust-awk/issues/61