### PR TITLE
Refactor: Further simplifications to Context

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -243,22 +243,21 @@ fn parse_assign_statement(input: &str) -> IResult<&str, Statement> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic_types::{Record, VariableStore, Variables};
+    use crate::basic_types::{VariableStore, Variables};
     use crate::function::Functions;
     use crate::value::{NumericValue, Value};
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn print_statement_produces_value() {
-        let (functions, mut empty_variables, record) = empty_variables_and_record();
+        let (functions, mut empty_variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut empty_variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let print_action = parse_action(r#"{ print("hello"); }"#).unwrap().1;
         assert_eq!(
@@ -269,9 +268,9 @@ mod tests {
 
     #[test]
     fn if_produces_correct_value() {
-        let (functions, mut empty_variables, record) = empty_variables_and_record();
+        let (functions, mut empty_variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut empty_variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let if_conditional = parse_action(
             r#"{
@@ -308,9 +307,9 @@ mod tests {
 
     #[test]
     fn assignment_updates_variables() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let assign_action = parse_action(
             r#"{
@@ -328,9 +327,9 @@ mod tests {
 
     #[test]
     fn test_parse_statements() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_print_statement(r#"print("hello")"#);
         assert!(result.is_ok());
@@ -360,9 +359,9 @@ mod tests {
 
     #[test]
     fn test_parse_if_else_statement() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_simple_statement(
             r#"if (1) {
@@ -381,9 +380,9 @@ mod tests {
 
     #[test]
     fn test_parse_while_statement() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_simple_statement(
             r#"while (0) {
@@ -403,9 +402,9 @@ mod tests {
 
     #[test]
     fn test_parse_do_while_statement() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_simple_statement(
             r#"do {
@@ -423,9 +422,9 @@ mod tests {
     }
     #[test]
     fn test_parse_assign_statement() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_simple_statement(r#"variable = "hi""#);
         let empty_vec: Vec<&'static str> = vec![];

--- a/src/action.rs
+++ b/src/action.rs
@@ -257,10 +257,9 @@ mod tests {
     #[test]
     fn print_statement_produces_value() {
         let (functions, mut empty_variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut empty_variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut empty_variables);
+        context.set_record(&record);
+
         let print_action = parse_action(r#"{ print("hello"); }"#).unwrap().1;
         assert_eq!(
             print_action.output_for_line(&functions, &mut context),
@@ -271,10 +270,8 @@ mod tests {
     #[test]
     fn if_produces_correct_value() {
         let (functions, mut empty_variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut empty_variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut empty_variables);
+        context.set_record(&record);
 
         let if_conditional = parse_action(
             r#"{
@@ -312,10 +309,8 @@ mod tests {
     #[test]
     fn assignment_updates_variables() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         let assign_action = parse_action(
             r#"{
@@ -334,10 +329,9 @@ mod tests {
     #[test]
     fn test_parse_statements() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let result = parse_print_statement(r#"print("hello")"#);
         assert!(result.is_ok());
         assert_eq!(
@@ -367,10 +361,9 @@ mod tests {
     #[test]
     fn test_parse_if_else_statement() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let result = parse_simple_statement(
             r#"if (1) {
             print("hello");
@@ -389,10 +382,9 @@ mod tests {
     #[test]
     fn test_parse_while_statement() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let result = parse_simple_statement(
             r#"while (0) {
                 print("hello");
@@ -412,10 +404,9 @@ mod tests {
     #[test]
     fn test_parse_do_while_statement() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let result = parse_simple_statement(
             r#"do {
                 print("hello");
@@ -433,10 +424,9 @@ mod tests {
     #[test]
     fn test_parse_assign_statement() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let result = parse_simple_statement(r#"variable = "hi""#);
         let empty_vec: Vec<&'static str> = vec![];
         assert!(result.is_ok());

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -1,7 +1,6 @@
 use crate::value::Value;
 use regex;
-
-use crate::function::StackFrame;
+use std::collections::HashMap;
 
 struct Record<'a> {
     full_line: &'a str,
@@ -67,6 +66,26 @@ impl<'a> MutableContext<'a> {
         let output = f(self);
         self.variables.function_variables.pop();
         output
+    }
+}
+
+pub(crate) struct StackFrame {
+    variables: HashMap<String, Value>,
+}
+
+impl StackFrame {
+    pub(crate) fn empty() -> StackFrame {
+        StackFrame {
+            variables: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
+        self.variables.get(variable_name).map(|val| val.clone())
+    }
+
+    pub(crate) fn assign_variable(&mut self, variable_name: &str, value: Value) {
+        self.variables.insert(variable_name.to_string(), value);
     }
 }
 

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -29,12 +29,12 @@ pub(crate) struct Variables {
 
 pub(crate) struct MutableContext<'a> {
     pub(crate) variables: &'a mut Variables,
-    pub(crate) record: Option<&'a Record<'a>>,
+    pub(crate) record: Option<Record<'a>>,
 }
 
 impl<'a> MutableContext<'a> {
     pub(crate) fn fetch_field(&self, index: i64) -> Value {
-        match self.record {
+        match &self.record {
             None => Value::String("".to_string()),
             Some(record) => match index {
                 i if i < 0 => panic!("Field indexes cannot be negative: {}", index),
@@ -55,8 +55,8 @@ impl<'a> MutableContext<'a> {
         }
     }
 
-    pub(crate) fn set_record(&mut self, record: &'a Record<'a>) {
-        self.record = Some(record);
+    pub(crate) fn set_record_with_line(&mut self, line: &'a str) {
+        self.record = Some(self.variables.record_for_line(line));
     }
 
     pub(crate) fn with_stack_frame<T, F>(&mut self, frame: StackFrame, f: F) -> T

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -48,6 +48,17 @@ impl<'a> MutableContext<'a> {
         }
     }
 
+    pub(crate) fn for_variables(variables: &mut Variables) -> MutableContext {
+        MutableContext {
+            variables: variables,
+            record: None,
+        }
+    }
+
+    pub(crate) fn set_record(&mut self, record: &'a Record<'a>) {
+        self.record = Some(record);
+    }
+
     pub(crate) fn with_stack_frame<T, F>(&mut self, frame: StackFrame, f: F) -> T
     where
         F: FnOnce(&mut Self) -> T,

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -3,7 +3,7 @@ use regex;
 
 use crate::function::StackFrame;
 
-pub(crate) struct Record<'a> {
+struct Record<'a> {
     full_line: &'a str,
     fields: Vec<&'a str>,
 }
@@ -28,8 +28,8 @@ pub(crate) struct Variables {
 }
 
 pub(crate) struct MutableContext<'a> {
-    pub(crate) variables: &'a mut Variables,
-    pub(crate) record: Option<Record<'a>>,
+    variables: &'a mut Variables,
+    record: Option<Record<'a>>,
 }
 
 impl<'a> MutableContext<'a> {
@@ -119,7 +119,7 @@ impl Variables {
         }
     }
 
-    pub(super) fn record_for_line<'a>(&self, line: &'a str) -> Record<'a> {
+    fn record_for_line<'a>(&self, line: &'a str) -> Record<'a> {
         let fields = match &self.field_separator {
             FieldSeparator::Character(' ') => line.split_whitespace().collect(),
             FieldSeparator::Character(c1) => line.split(|c2| *c1 == c2).collect(),

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -47,6 +47,16 @@ impl<'a> MutableContext<'a> {
             },
         }
     }
+
+    pub(crate) fn with_stack_frame<T, F>(&mut self, frame: StackFrame, f: F) -> T
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        self.variables.function_variables.push(frame);
+        let output = f(self);
+        self.variables.function_variables.pop();
+        output
+    }
 }
 
 impl VariableStore for MutableContext<'_> {
@@ -96,16 +106,6 @@ impl Variables {
         } else {
             self.field_separator = FieldSeparator::Regex(regex::Regex::new(new_separator).unwrap())
         }
-    }
-
-    pub(crate) fn with_stack_frame<T, F>(&mut self, frame: StackFrame, f: F) -> T
-    where
-        F: Fn(&mut Variables) -> T,
-    {
-        self.function_variables.push(frame);
-        let output = f(self);
-        self.function_variables.pop();
-        output
     }
 
     pub(super) fn record_for_line<'a>(&self, line: &'a str) -> Record<'a> {

--- a/src/basic_types.rs
+++ b/src/basic_types.rs
@@ -80,7 +80,7 @@ impl StackFrame {
         }
     }
 
-    pub(crate) fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
+    fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
         self.variables.get(variable_name).map(|val| val.clone())
     }
 

--- a/src/expression/binary_comparison.rs
+++ b/src/expression/binary_comparison.rs
@@ -148,10 +148,9 @@ mod tests {
     #[test]
     fn test_comparing_numbers() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = comparison_parser(parse_literal);
 
         let result = parser("1 < 2");
@@ -172,10 +171,9 @@ mod tests {
     #[test]
     fn test_comparing_strings() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = comparison_parser(parse_literal);
 
         let result = parser(r#""a" < "b""#);
@@ -196,10 +194,9 @@ mod tests {
     #[test]
     fn test_comparing_numbers_and_strings() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = comparison_parser(parse_literal);
 
         // Numbers come before letters

--- a/src/expression/binary_comparison.rs
+++ b/src/expression/binary_comparison.rs
@@ -135,21 +135,20 @@ where
 mod tests {
     use super::super::literal::*;
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn test_comparing_numbers() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = comparison_parser(parse_literal);
 
@@ -170,9 +169,9 @@ mod tests {
 
     #[test]
     fn test_comparing_strings() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = comparison_parser(parse_literal);
 
@@ -193,9 +192,9 @@ mod tests {
 
     #[test]
     fn test_comparing_numbers_and_strings() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = comparison_parser(parse_literal);
 

--- a/src/expression/binary_math.rs
+++ b/src/expression/binary_math.rs
@@ -193,10 +193,9 @@ mod tests {
     #[test]
     fn binary_expressions_can_evaluate() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         assert_eq!(
             BinaryMath {
                 left: Box::new(Literal::Numeric(NumericValue::Integer(2))),
@@ -211,10 +210,9 @@ mod tests {
     #[test]
     fn binary_expressions_can_parse() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = addition_parser(multiplication_parser(parse_literal));
 
         let result = parser("1 + 2 - 3 + 4 - 5.5");

--- a/src/expression/binary_math.rs
+++ b/src/expression/binary_math.rs
@@ -180,21 +180,20 @@ where
 mod tests {
     use super::super::literal::*;
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn binary_expressions_can_evaluate() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         assert_eq!(
             BinaryMath {
@@ -209,9 +208,9 @@ mod tests {
 
     #[test]
     fn binary_expressions_can_parse() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = addition_parser(multiplication_parser(parse_literal));
 

--- a/src/expression/boolean.rs
+++ b/src/expression/boolean.rs
@@ -148,21 +148,20 @@ where
 mod tests {
     use super::super::literal::*;
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn test_and_parsing() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = and_parser(parse_literal);
 
@@ -190,9 +189,9 @@ mod tests {
 
     #[test]
     fn test_or_parsing() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = or_parser(parse_literal);
 
@@ -227,9 +226,9 @@ mod tests {
 
     #[test]
     fn test_not_parsing() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = not_parser(parse_literal);
 
@@ -271,9 +270,9 @@ mod tests {
 
     #[test]
     fn test_iteration_compression() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = not_parser(parse_literal);
 

--- a/src/expression/boolean.rs
+++ b/src/expression/boolean.rs
@@ -161,10 +161,9 @@ mod tests {
     #[test]
     fn test_and_parsing() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = and_parser(parse_literal);
 
         let result = parser(r#""a" && 1"#);
@@ -192,10 +191,9 @@ mod tests {
     #[test]
     fn test_or_parsing() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = or_parser(parse_literal);
 
         let result = parser(r#""a" || 1"#);
@@ -230,10 +228,9 @@ mod tests {
     #[test]
     fn test_not_parsing() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = not_parser(parse_literal);
 
         let result = parser(r#"!1"#);
@@ -275,10 +272,9 @@ mod tests {
     #[test]
     fn test_iteration_compression() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = not_parser(parse_literal);
 
         let result = parser(r#""abc""#);

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -57,22 +57,20 @@ where
 mod tests {
     use super::super::literal::*;
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn field_reference_can_evaluate() {
-        let (functions, mut variables, _) = empty_variables_and_record();
-        let record = variables.record_for_line("first second");
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("first second");
 
         assert_eq!(
             FieldReference {
@@ -85,9 +83,9 @@ mod tests {
 
     #[test]
     fn test_parse_field_reference() {
-        let (functions, mut variables, mut record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = field_reference_parser(parse_literal);
 
@@ -99,9 +97,7 @@ mod tests {
             Value::Uninitialized,
         );
 
-        record = variables.record_for_line("hello");
-        context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("hello");
         assert_eq!(
             expression.evaluate(&functions, &mut context),
             Value::String("hello".to_string()),
@@ -117,10 +113,9 @@ mod tests {
 
     // #[test]
     // fn test_nested_field_references() {
-    //     let (functions, mut variables, mut record) = empty_variables_and_record();
+    //     let (functions, mut variables, mut record) = empty_functions_and_variables();
     //     let mut context = MutableContext::for_variables(&mut variables);
-    //     context.set_record(&record);
-    //     record.fields = vec!["2", "3", "hello"];
+    //     context.set_record_with_line("2 3 hello");
 
     //     let parser = field_reference_parser(parse_literal);
     //     let result = parser("$$$1");

--- a/src/expression/field_reference.rs
+++ b/src/expression/field_reference.rs
@@ -71,10 +71,8 @@ mod tests {
     fn field_reference_can_evaluate() {
         let (functions, mut variables, _) = empty_variables_and_record();
         let record = variables.record_for_line("first second");
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         assert_eq!(
             FieldReference {
@@ -88,10 +86,9 @@ mod tests {
     #[test]
     fn test_parse_field_reference() {
         let (functions, mut variables, mut record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = field_reference_parser(parse_literal);
 
         let result = parser("$1");
@@ -103,10 +100,8 @@ mod tests {
         );
 
         record = variables.record_for_line("hello");
-        context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
         assert_eq!(
             expression.evaluate(&functions, &mut context),
             Value::String("hello".to_string()),
@@ -123,10 +118,8 @@ mod tests {
     // #[test]
     // fn test_nested_field_references() {
     //     let (functions, mut variables, mut record) = empty_variables_and_record();
-    //     let mut context = MutableContext {
-    //         variables: &mut variables,
-    //         record: Some(&record),
-    //     };
+    //     let mut context = MutableContext::for_variables(&mut variables);
+    //     context.set_record(&record);
     //     record.fields = vec!["2", "3", "hello"];
 
     //     let parser = field_reference_parser(parse_literal);

--- a/src/expression/literal.rs
+++ b/src/expression/literal.rs
@@ -96,21 +96,20 @@ fn parse_regex_literal(input: &str) -> ExpressionParseResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn literals_can_evaluate() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let string = Literal::String("hello".to_string());
         assert_eq!(
@@ -126,9 +125,9 @@ mod tests {
 
     #[test]
     fn test_parse_literals() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_literal("1");
         assert_eq!(result.is_ok(), true);

--- a/src/expression/literal.rs
+++ b/src/expression/literal.rs
@@ -109,10 +109,9 @@ mod tests {
     #[test]
     fn literals_can_evaluate() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let string = Literal::String("hello".to_string());
         assert_eq!(
             string.evaluate(&functions, &mut context),
@@ -128,10 +127,8 @@ mod tests {
     #[test]
     fn test_parse_literals() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         let result = parse_literal("1");
         assert_eq!(result.is_ok(), true);

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -83,22 +83,21 @@ fn parse_parens(input: &str) -> ExpressionParseResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use crate::value::NumericValue;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn test_parse_parens() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_expression("( 1 )");
         assert_eq!(result.is_ok(), true);
@@ -117,9 +116,9 @@ mod tests {
 
     #[test]
     fn test_boolean_precedence() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_expression("1 && 1 || 0 && 1");
         assert_eq!(result.is_ok(), true);

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -97,10 +97,8 @@ mod tests {
     #[test]
     fn test_parse_parens() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         let result = parse_expression("( 1 )");
         assert_eq!(result.is_ok(), true);
@@ -120,10 +118,8 @@ mod tests {
     #[test]
     fn test_boolean_precedence() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         let result = parse_expression("1 && 1 || 0 && 1");
         assert_eq!(result.is_ok(), true);

--- a/src/expression/regex_match.rs
+++ b/src/expression/regex_match.rs
@@ -98,10 +98,9 @@ mod tests {
     #[test]
     fn test_regex_match() {
         let (functions, mut variables, record) = empty_variables_and_record();
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
+
         let parser = regex_parser(addition_parser(parse_literal));
 
         let result = parser("1 ~ 2");

--- a/src/expression/regex_match.rs
+++ b/src/expression/regex_match.rs
@@ -85,21 +85,20 @@ where
 mod tests {
     use super::super::{binary_math::addition_parser, literal::parse_literal};
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn test_regex_match() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let parser = regex_parser(addition_parser(parse_literal));
 

--- a/src/expression/variable.rs
+++ b/src/expression/variable.rs
@@ -79,10 +79,8 @@ mod tests {
         let (functions, mut variables, record) = empty_variables_and_record();
         let value = Value::Numeric(NumericValue::Integer(1));
         variables.assign_variable("foo", value.clone());
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         assert_eq!(
             Variable {
@@ -103,10 +101,8 @@ mod tests {
         let function = result.unwrap().1;
         functions.insert("foo".to_string(), function);
 
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
 
         let result = parse_assignable_variable("foo");
         assert!(result.is_ok());

--- a/src/expression/variable.rs
+++ b/src/expression/variable.rs
@@ -63,24 +63,23 @@ pub fn parse_variable_name(input: &str) -> IResult<&str, &str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic_types::{Record, Variables};
+    use crate::basic_types::Variables;
     use crate::function::{parse_function, Functions};
     use crate::value::NumericValue;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn variables_can_evaluate() {
-        let (functions, mut variables, record) = empty_variables_and_record();
+        let (functions, mut variables) = empty_functions_and_variables();
         let value = Value::Numeric(NumericValue::Integer(1));
         variables.assign_variable("foo", value.clone());
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         assert_eq!(
             Variable {
@@ -94,7 +93,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn blocks_name_collisions() {
-        let (mut functions, mut variables, record) = empty_variables_and_record();
+        let (mut functions, mut variables) = empty_functions_and_variables();
         let value = Value::Numeric(NumericValue::Integer(1));
         let result = parse_function(r#"function foo(a) {}"#);
         assert!(result.is_ok());
@@ -102,7 +101,7 @@ mod tests {
         functions.insert("foo".to_string(), function);
 
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("");
 
         let result = parse_assignable_variable("foo");
         assert!(result.is_ok());

--- a/src/function.rs
+++ b/src/function.rs
@@ -11,30 +11,10 @@ use std::ops::Index;
 
 use crate::{
     action::{parse_action, Action},
-    basic_types::{MutableContext, UNINITIALIZED_VALUE},
+    basic_types::{MutableContext, StackFrame, UNINITIALIZED_VALUE},
     expression::variable::parse_variable_name,
     value::Value,
 };
-
-pub(crate) struct StackFrame {
-    variables: HashMap<String, Value>,
-}
-
-impl StackFrame {
-    pub(crate) fn empty() -> StackFrame {
-        StackFrame {
-            variables: HashMap::new(),
-        }
-    }
-
-    pub(crate) fn fetch_variable(&self, variable_name: &str) -> Option<Value> {
-        self.variables.get(variable_name).map(|val| val.clone())
-    }
-
-    pub(crate) fn assign_variable(&mut self, variable_name: &str, value: Value) {
-        self.variables.insert(variable_name.to_string(), value);
-    }
-}
 
 pub(crate) struct FunctionDefinition {
     pub(crate) name: String,

--- a/src/function.rs
+++ b/src/function.rs
@@ -72,16 +72,7 @@ impl FunctionDefinition {
         // Right now, a function can only be invoked as a Statement with printable outputs.
         // In the future, a function will need to be both a "statement" (returning outputs) AND an
         // expression (having a nestable value)
-        let record = context.record;
-        context.variables.with_stack_frame(frame, |v| {
-            self.body.output_for_line(
-                functions,
-                &mut MutableContext {
-                    variables: v,
-                    record: record,
-                },
-            )
-        })
+        context.with_stack_frame(frame, |c| self.body.output_for_line(functions, c))
     }
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -32,10 +32,9 @@ impl Item {
     ) -> Vec<String> {
         if let Pattern::Begin = self.pattern {
             let record = variables.record_for_line("");
-            let mut context = MutableContext {
-                variables: variables,
-                record: Some(&record),
-            };
+            let mut context = MutableContext::for_variables(variables);
+            context.set_record(&record);
+
             self.action.output_for_line(functions, &mut context)
         } else {
             vec![]
@@ -70,10 +69,8 @@ mod tests {
     fn test_full_item_parsing() {
         let (functions, mut variables, _) = empty_variables_and_record();
         let record = variables.record_for_line("hello world today");
-        let mut context = MutableContext {
-            variables: &mut variables,
-            record: Some(&record),
-        };
+        let mut context = MutableContext::for_variables(&mut variables);
+        context.set_record(&record);
         let empty_string_vec: Vec<&'static str> = vec![];
 
         let result = parse_item(r#"$1 ~ "hello" { print($0); }"#);

--- a/src/item.rs
+++ b/src/item.rs
@@ -31,9 +31,8 @@ impl Item {
         variables: &mut Variables,
     ) -> Vec<String> {
         if let Pattern::Begin = self.pattern {
-            let record = variables.record_for_line("");
             let mut context = MutableContext::for_variables(variables);
-            context.set_record(&record);
+            context.set_record_with_line("");
 
             self.action.output_for_line(functions, &mut context)
         } else {
@@ -55,22 +54,19 @@ pub(crate) fn parse_item(input: &str) -> IResult<&str, Item> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::basic_types::Record;
     use crate::function::Functions;
     use std::collections::HashMap;
 
-    fn empty_variables_and_record() -> (Functions, Variables, Record<'static>) {
+    fn empty_functions_and_variables() -> (Functions, Variables) {
         let variables = Variables::empty();
-        let record = variables.record_for_line("");
-        (HashMap::new(), variables, record)
+        (HashMap::new(), variables)
     }
 
     #[test]
     fn test_full_item_parsing() {
-        let (functions, mut variables, _) = empty_variables_and_record();
-        let record = variables.record_for_line("hello world today");
+        let (functions, mut variables) = empty_functions_and_variables();
         let mut context = MutableContext::for_variables(&mut variables);
-        context.set_record(&record);
+        context.set_record_with_line("hello world today");
         let empty_string_vec: Vec<&'static str> = vec![];
 
         let result = parse_item(r#"$1 ~ "hello" { print($0); }"#);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,11 +101,10 @@ pub fn start_run(args: Vec<String>) -> (ProgramRun, Vec<String>) {
 
 impl ProgramRun {
     pub fn output_for_line(&mut self, line: &str) -> Vec<String> {
-        let mut record = self.variables.record_for_line(line);
         // Need explicit borrow of the variables to avoid borrowing `self` later
         let functions = &self.program.functions;
         let mut context = MutableContext::for_variables(&mut self.variables);
-        context.set_record(&mut record);
+        context.set_record_with_line(line);
 
         self.program
             .items

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,8 @@ impl ProgramRun {
         let mut record = self.variables.record_for_line(line);
         // Need explicit borrow of the variables to avoid borrowing `self` later
         let functions = &self.program.functions;
-        let mut context = MutableContext {
-            variables: &mut self.variables,
-            record: Some(&mut record),
-        };
+        let mut context = MutableContext::for_variables(&mut self.variables);
+        context.set_record(&mut record);
 
         self.program
             .items


### PR DESCRIPTION
Specific change is to Hide `Record` and allow `MutableContext` to wholly manage interactions with that data