### PR TITLE
Add built in variables

### DIFF
--- a/src/action/print.rs
+++ b/src/action/print.rs
@@ -8,7 +8,7 @@ use nom::{
 
 use super::Statement;
 use crate::{
-    context::MutableContext,
+    context::{MutableContext, VariableStore},
     expression::{parse_expression, Expression},
     function::Functions,
     printable::Printable,
@@ -32,7 +32,7 @@ impl Statement for Print {
             })
             .and_then(|strings| Printable {
                 value: (),
-                output: vec![strings.join(" ")],
+                output: vec![strings.join(&context.fetch_variable("OFS").coerce_to_string())],
             })
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,4 +1,4 @@
-use crate::value::Value;
+use crate::value::{NumericValue, Value};
 
 pub(crate) mod stack_frame;
 pub(crate) mod variables;
@@ -46,6 +46,10 @@ impl<'a> MutableContext<'a> {
 
     pub(crate) fn set_record_with_line(&mut self, line: &'a str) {
         self.record = self.variables.record_for_line(line);
+        self.variables.assign_variable(
+            "NF",
+            Value::Numeric(NumericValue::Integer(self.record.fields.len() as i64)),
+        );
     }
 
     pub(crate) fn with_stack_frame<T, F>(&mut self, frame: StackFrame, f: F) -> T

--- a/src/context/variables.rs
+++ b/src/context/variables.rs
@@ -16,11 +16,20 @@ pub(crate) struct Variables {
 
 impl Variables {
     pub(crate) fn empty() -> Variables {
-        Variables {
+        let mut default_variables = Variables {
             field_separator: FieldSeparator::Character(' '),
             global_variables: StackFrame::empty(),
             function_variables: vec![],
-        }
+        };
+
+        // Assign all default variable values
+        default_variables.assign_variable("NR", Value::Numeric(NumericValue::Integer(0)));
+        default_variables.assign_variable("OFS", Value::String(" ".to_string()));
+        default_variables.assign_variable("ORS", Value::String("\n".to_string()));
+        default_variables.assign_variable("OFMT", Value::String("%.6g".to_string()));
+        default_variables.assign_variable("CONVFMT", Value::String("%.6g".to_string()));
+
+        default_variables
     }
 
     pub(super) fn set_field_separator(&mut self, new_separator: &str) {

--- a/src/context/variables.rs
+++ b/src/context/variables.rs
@@ -1,7 +1,7 @@
 use regex;
 
 use crate::context::{stack_frame::StackFrame, Record, VariableStore};
-use crate::value::{Value, UNINITIALIZED_VALUE};
+use crate::value::{NumericValue, Value, UNINITIALIZED_VALUE};
 
 pub(super) enum FieldSeparator {
     Character(char),

--- a/src/context/variables.rs
+++ b/src/context/variables.rs
@@ -32,7 +32,7 @@ impl Variables {
         default_variables
     }
 
-    pub(super) fn set_field_separator(&mut self, new_separator: &str) {
+    fn set_field_separator(&mut self, new_separator: &str) {
         if new_separator.len() == 1 {
             self.field_separator = FieldSeparator::Character(new_separator.chars().next().unwrap())
         } else {

--- a/src/context/variables.rs
+++ b/src/context/variables.rs
@@ -3,13 +3,13 @@ use regex;
 use crate::context::{stack_frame::StackFrame, Record, VariableStore};
 use crate::value::{NumericValue, Value, UNINITIALIZED_VALUE};
 
-pub(super) enum FieldSeparator {
+enum FieldSeparator {
     Character(char),
     Regex(regex::Regex),
 }
 
 pub(crate) struct Variables {
-    pub(super) field_separator: FieldSeparator,
+    field_separator: FieldSeparator,
     pub(super) global_variables: StackFrame,
     pub(super) function_variables: Vec<StackFrame>,
 }

--- a/src/context/variables.rs
+++ b/src/context/variables.rs
@@ -42,6 +42,17 @@ impl Variables {
             fields: fields,
         }
     }
+
+    pub(crate) fn increment_variable(&mut self, variable_name: &str) {
+        match self.fetch_variable(variable_name).coerce_to_numeric() {
+            NumericValue::Integer(i) => {
+                self.assign_variable(variable_name, Value::Numeric(NumericValue::Integer(i + 1)))
+            }
+            NumericValue::Float(f) => {
+                self.assign_variable(variable_name, Value::Numeric(NumericValue::Float(f + 1.0)))
+            }
+        };
+    }
 }
 
 impl VariableStore for Variables {

--- a/src/program_run.rs
+++ b/src/program_run.rs
@@ -33,11 +33,9 @@ impl<T: Read> LineReadable for BufReader<T> {
 
 impl ProgramRun {
     pub(crate) fn new_for_program(program: Program) -> ProgramRun {
-        let mut variables = Variables::empty();
-        variables.assign_variable("NR", Value::Numeric(NumericValue::Integer(0)));
         ProgramRun {
             program: program,
-            variables: variables,
+            variables: Variables::empty(),
         }
     }
 
@@ -102,6 +100,11 @@ impl ProgramRun {
     pub(super) fn apply_args(&mut self, args: &parse_args::Args) {
         self.variables
             .assign_variable("FS", Value::String(args.field_separator.clone()));
+        self.variables.assign_variable(
+            "ARGC",
+            Value::Numeric(NumericValue::Integer(args.filepaths_to_parse.len() as i64)),
+        );
+
         for (name, value) in args.variables.iter() {
             self.variables
                 .assign_variable(name, Value::String(value.to_string()));


### PR DESCRIPTION
This adds the readability of built-in variables, and technically the writing behavior as well, but some variables have not yet had their downstream behavior implemented.

Variables fully implemented:
- `FS` = Separator used to split fields from input
- `NR` = Sequence number of the current record, across all files processed thus far
- `NF` = Sequence number of the current file
- `FNR` = Record number within the current file
- `OFS` = Separator used to join the values printed out
- `ARGC` = Number of input file paths provided to read

Variables whose output behavior hasn't been implemented:
- `OFMT` = The format string used when converting floats to strings during printing
- `CONVFMT` = The format string used when converting floats to strings during computation
- `ORS` = The character/string used to separate output lines
- `RS` = The character/string used to split input records (typically newline -> split on lines)